### PR TITLE
'How to use' section is now also collapsible

### DIFF
--- a/pages/software/v0.2/ChecklistPreamble.vue
+++ b/pages/software/v0.2/ChecklistPreamble.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="preamble">
+    <div>
         <h2>How to use this page</h2>
         <p>
             If you are a research software author, please answer the questions below to
@@ -131,14 +131,7 @@ const collapseHowtouse = () => {
 <style scoped>
 h2 {
     color: var(--white);
-    margin-top: 3em;
-    margin-left: auto;
-    margin-right: auto;
-    text-align: center;
-}
-div.preamble {
-    margin-left: 4em;
-    margin-right: 4em;
+    font-size: 1.2em;
 }
 li {
     padding-bottom: 0.5em;

--- a/pages/software/v0.2/ChecklistPreamble.vue
+++ b/pages/software/v0.2/ChecklistPreamble.vue
@@ -7,45 +7,60 @@
             the bottom of the screen will update according to your answers. When you're done
             with the questions, copy the badge at the bottom of the page and put it in your
             software's README.
+            <span v-if="showCollapsedHowtouse"
+                v-on:click="expandHowtouse"
+                class="anchor-like">
+                Read more.
+            </span>
         </p>
-        This way, you
-        <ol>
-            <li>
-                <i>Promote transparency</i>: the badge links back to this page, and
-                contains the required data to check the appropriate answers. This way,
-                users of your software can easily get an idea of the FAIRness state of
-                the project.
-            </li>
-            <li>
-                <i>Discover best practices</i>: as you go through the questions, you may
-                learn about practices to improve FAIRness that you were not aware of
-                previously.
-            </li>
-            <li>
-                <i>Become an ambassador of FAIR</i>: By putting the badge in your
-                README, your project will help promote the previous 2 aspects.
-            </li>
-        </ol>
-        <p>
-            The questions are inspired by the outcomes of the FAIR4RS Working Group (see
-            <a href="https://doi.org/10.15497/RDA00068">doi:10.15497/RDA00068</a>). We
-            gratefully acknowledge their contribution.
-        </p>
+        <div
+            class="expands"
+            v-bind:class="{expanded: showExpandedHowtouse, collapsed: showCollapsedHowtouse}">
+            This way, you
+            <ol>
+                <li>
+                    <i>Promote transparency</i>: the badge links back to this page, and
+                    contains the required data to check the appropriate answers. This way,
+                    users of your software can easily get an idea of the FAIRness state of
+                    the project.
+                </li>
+                <li>
+                    <i>Discover best practices</i>: as you go through the questions, you may
+                    learn about practices to improve FAIRness that you were not aware of
+                    previously.
+                </li>
+                <li>
+                    <i>Become an ambassador of FAIR</i>: By putting the badge in your
+                    README, your project will help promote the previous 2 aspects.
+                </li>
+            </ol>
+            <p>
+                The questions are inspired by the outcomes of the FAIR4RS Working Group (see
+                <a href="https://doi.org/10.15497/RDA00068">doi:10.15497/RDA00068</a>). We
+                gratefully acknowledge their contribution. <span
+                    v-on:click="collapseHowtouse"
+                    class="anchor-like">
+                    Collapse this section.
+                </span>
+            </p>
+        </div>
         <h2>Definitions</h2>
         <p>
             For the questions that follow, it is helpful to specify what we
             mean by "the software". Our recommendation is to interpret that
             phrase as "a specific copy of a specific version of your software-as-a-concept".
-            <span v-if="showCollapsed">
+            <span v-if="showCollapsedDefinitions">
                 For many projects,...
                 <span
-                    v-on:click="expand"
+                    v-on:click="expandDefinitions"
                     class="anchor-like">
                     Read more.
                 </span>
             </span>
         </p>
-        <div class="expands" v-bind:class="{expanded: showExpanded, collapsed: showCollapsed}">
+        <div
+            class="expands"
+            v-bind:class="{expanded: showExpandedDefinitions, collapsed: showCollapsedDefinitions}">
             <p>
                 For many projects, the
                 specific copy will be some kind of nested directory tree structure with files
@@ -75,9 +90,9 @@
                 APIs (for example the GitHub, GitLab, Zenodo, PyPI, CRAN, or NPM API) should not
                 be considered metadata for the purposes of this checklist.
                 <span
-                    v-on:click="collapse"
+                    v-on:click="collapseDefinitions"
                     class="anchor-like">
-                    Collapse the explanatory text.
+                    Collapse this section.
                 </span>
             </p>
         </div>
@@ -91,15 +106,25 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 
-const showCollapsed = ref(true);
-const showExpanded = ref(false);
-const expand = () => {
-    showCollapsed.value = false;
-    showExpanded.value = true;
+const showCollapsedDefinitions = ref(true);
+const showExpandedDefinitions = ref(false);
+const expandDefinitions = () => {
+    showCollapsedDefinitions.value = false;
+    showExpandedDefinitions.value = true;
 };
-const collapse = () => {
-    showCollapsed.value = true;
-    showExpanded.value = false;
+const collapseDefinitions = () => {
+    showCollapsedDefinitions.value = true;
+    showExpandedDefinitions.value = false;
+};
+const showCollapsedHowtouse = ref(true);
+const showExpandedHowtouse = ref(false);
+const expandHowtouse = () => {
+    showCollapsedHowtouse.value = false;
+    showExpandedHowtouse.value = true;
+};
+const collapseHowtouse = () => {
+    showCollapsedHowtouse.value = true;
+    showExpandedHowtouse.value = false;
 };
 </script>
 

--- a/pages/software/v0.2/index.page.vue
+++ b/pages/software/v0.2/index.page.vue
@@ -4,7 +4,7 @@
         <ChecklistHeader />
         <main>
             <h1>Self-assessment for FAIR research software</h1>
-            <p>
+            <p class="data-variant">
                 For the data variant, click
                 <ChecklistLink v-bind:href="linkToDataChecklist">here</ChecklistLink>.
             </p>
@@ -141,6 +141,7 @@ main {
 h1 {
     line-height: 1.2em;
     margin-top: 1em;
+    margin-bottom: 0.25em;
 }
 h2 {
     width: 40%;
@@ -149,6 +150,10 @@ h2 {
     margin-left: auto;
     margin-right: auto;
     text-align: center;
+}
+p.data-variant {
+    margin-bottom: 4em;
+    margin-top: 0em;
 }
 
 p.principle-quote {


### PR DESCRIPTION
This PR makes the "How to use" section collapsible. Also added a few style changes.


![image](https://user-images.githubusercontent.com/4558105/226302415-af2df837-ee80-44d0-b69e-061890e9d692.png)

